### PR TITLE
Fixed DLL path for the 64-bits library

### DIFF
--- a/src/main/java/edsdk/utils/DLL_Setup.java
+++ b/src/main/java/edsdk/utils/DLL_Setup.java
@@ -113,8 +113,8 @@ public class DLL_Setup {
       libName=libName.toUpperCase();
       result.hint= libName+" DLL";
       if (arch != null && arch.endsWith("64")) {
-        // e.g. EDSDK_64/EDSDK.dll
-        result.dllLoc = libName+"_64/"+libName+".dll";
+        // e.g. EDSDK_64/Dll/EDSDK.dll
+        result.dllLoc = libName+"_64/Dll/"+libName+".dll";
       } else {
         // e.g. EDSDK/Dll/EDSDK.dll
         result.dllLoc = libName+"/Dll/"+libName+".dll";


### PR DESCRIPTION
In the latest version of the SDK, the 64-bit DLL is inside a `Dll` folder just like the 32-bit version.

I'm not sure whether this is a bug or the folder structure was different in previous versions of the SDK.